### PR TITLE
Solved error with array_key_exists function for PHP 8

### DIFF
--- a/latch/vendor/ElevenPaths/latch-sdk-php/src/Error.php
+++ b/latch/vendor/ElevenPaths/latch-sdk-php/src/Error.php
@@ -33,7 +33,7 @@ class Error {
 	 */
 	function __construct($json) {
 		$json = is_string($json)? json_decode($json) : $json;
-		if(array_key_exists("code", $json) && array_key_exists("message", $json)) {
+		if(array_key_exists("code", (array) $json) && array_key_exists("message", (array) $json)) {
 			$this->code = $json->{"code"};
 			$this->message = $json->{"message"};
 		} else {

--- a/latch/vendor/ElevenPaths/latch-sdk-php/src/LatchResponse.php
+++ b/latch/vendor/ElevenPaths/latch-sdk-php/src/LatchResponse.php
@@ -46,10 +46,10 @@ class LatchResponse {
 	public function __construct($jsonString) {
 		$json = json_decode($jsonString);
 		if(!is_null($json)) {
-			if (array_key_exists("data", $json)) {
+			if (array_key_exists("data", (array) $json)) {
 				$this->data = $json->{"data"};
 			}
-			if (array_key_exists("error", $json)) {
+			if (array_key_exists("error", (array) $json)) {
 				$this->error = new Error($json->{"error"});
 			} 
 		}


### PR DESCRIPTION
Solved Fatal error: Uncaught TypeError: array_key_exists(): Argument 2 ($array) must be of type array

The original error was in LatchResponse.php but Error.php use this function too.


#17 
I tested in Wordpress 5.9.3 with PHP 8
